### PR TITLE
GitHub API で sort, order のパラメータを付けてリクエスト。正確なソート順でテーブルビューに表示。

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		386069A429FD164300BCF6AE /* RepositoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386069A329FD164300BCF6AE /* RepositoryItem.swift */; };
 		388949C92A17E57100307A11 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949C82A17E57100307A11 /* Order.swift */; };
 		388949CB2A17E5F500307A11 /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949CA2A17E5F500307A11 /* RepositoryManager.swift */; };
+		388949CD2A18C63000307A11 /* RepositoryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949CC2A18C63000307A11 /* RepositoryEntity.swift */; };
 		38D37C632A1650B0005EA7C6 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 38D37C622A1650B0005EA7C6 /* .swiftlint.yml */; };
 		38D37C652A168715005EA7C6 /* GitHubSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D37C642A168715005EA7C6 /* GitHubSearchView.swift */; };
 		38D37C692A16885A005EA7C6 /* GitHubSearchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D37C682A16885A005EA7C6 /* GitHubSearchUsecase.swift */; };
@@ -69,6 +70,7 @@
 		386069A329FD164300BCF6AE /* RepositoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryItem.swift; sourceTree = "<group>"; };
 		388949C82A17E57100307A11 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
 		388949CA2A17E5F500307A11 /* RepositoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryManager.swift; sourceTree = "<group>"; };
+		388949CC2A18C63000307A11 /* RepositoryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryEntity.swift; sourceTree = "<group>"; };
 		38D37C622A1650B0005EA7C6 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		38D37C642A168715005EA7C6 /* GitHubSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchView.swift; sourceTree = "<group>"; };
 		38D37C682A16885A005EA7C6 /* GitHubSearchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchUsecase.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				38F34E6929F91F7100120671 /* GitHubSearchEntity.swift */,
+				388949CC2A18C63000307A11 /* RepositoryEntity.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -606,6 +609,7 @@
 				BF0A658D244F2A3B00280FA6 /* GitHubDetailViewController.swift in Sources */,
 				38F34E6829F91F5400120671 /* GitHubSearchPresenter.swift in Sources */,
 				386069A029FC0CC400BCF6AE /* UIImageView+Extension.swift in Sources */,
+				388949CD2A18C63000307A11 /* RepositoryEntity.swift in Sources */,
 				38D37C652A168715005EA7C6 /* GitHubSearchView.swift in Sources */,
 				38F34E6C29F91F8C00120671 /* GitHubSearchRouter.swift in Sources */,
 				38D37C692A16885A005EA7C6 /* GitHubSearchUsecase.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -10,7 +10,9 @@
 		049329AF80B2D1AF611F8FBE /* Pods_iOSEngineerCodeCheckTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6800159216A43DB8C841CD73 /* Pods_iOSEngineerCodeCheckTests.framework */; };
 		08BF68F158EBC28B42E4CFAD /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 282A5810E3EA27C8C1BD0C41 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */; };
 		386069A029FC0CC400BCF6AE /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3860699F29FC0CC400BCF6AE /* UIImageView+Extension.swift */; };
-		386069A429FD164300BCF6AE /* StarOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386069A329FD164300BCF6AE /* StarOrder.swift */; };
+		386069A429FD164300BCF6AE /* RepositoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386069A329FD164300BCF6AE /* RepositoryItem.swift */; };
+		388949C92A17E57100307A11 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949C82A17E57100307A11 /* Order.swift */; };
+		388949CB2A17E5F500307A11 /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949CA2A17E5F500307A11 /* RepositoryManager.swift */; };
 		38D37C632A1650B0005EA7C6 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 38D37C622A1650B0005EA7C6 /* .swiftlint.yml */; };
 		38D37C652A168715005EA7C6 /* GitHubSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D37C642A168715005EA7C6 /* GitHubSearchView.swift */; };
 		38D37C692A16885A005EA7C6 /* GitHubSearchUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D37C682A16885A005EA7C6 /* GitHubSearchUsecase.swift */; };
@@ -64,7 +66,9 @@
 		282A5810E3EA27C8C1BD0C41 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A7C55CFD63E6B2D8C5483EB /* Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; path = "Target Support Files/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		3860699F29FC0CC400BCF6AE /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
-		386069A329FD164300BCF6AE /* StarOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarOrder.swift; sourceTree = "<group>"; };
+		386069A329FD164300BCF6AE /* RepositoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryItem.swift; sourceTree = "<group>"; };
+		388949C82A17E57100307A11 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
+		388949CA2A17E5F500307A11 /* RepositoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryManager.swift; sourceTree = "<group>"; };
 		38D37C622A1650B0005EA7C6 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		38D37C642A168715005EA7C6 /* GitHubSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchView.swift; sourceTree = "<group>"; };
 		38D37C682A16885A005EA7C6 /* GitHubSearchUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchUsecase.swift; sourceTree = "<group>"; };
@@ -155,6 +159,16 @@
 			path = App;
 			sourceTree = "<group>";
 		};
+		388949C72A17E47E00307A11 /* Entity */ = {
+			isa = PBXGroup;
+			children = (
+				388949C82A17E57100307A11 /* Order.swift */,
+				386069A329FD164300BCF6AE /* RepositoryItem.swift */,
+				388949CA2A17E5F500307A11 /* RepositoryManager.swift */,
+			);
+			path = Entity;
+			sourceTree = "<group>";
+		};
 		38F34E5F29F91E6400120671 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -188,7 +202,6 @@
 			isa = PBXGroup;
 			children = (
 				38F34E6929F91F7100120671 /* GitHubSearchEntity.swift */,
-				386069A329FD164300BCF6AE /* StarOrder.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -209,6 +222,7 @@
 				38F34E6029F91E7000120671 /* Interactor */,
 				38F34E6129F91E8400120671 /* Presenter */,
 				38F34E6329F91EA900120671 /* Router */,
+				388949C72A17E47E00307A11 /* Entity */,
 			);
 			path = GitHubSearch;
 			sourceTree = "<group>";
@@ -576,7 +590,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				38F34E6A29F91F7100120671 /* GitHubSearchEntity.swift in Sources */,
-				386069A429FD164300BCF6AE /* StarOrder.swift in Sources */,
+				386069A429FD164300BCF6AE /* RepositoryItem.swift in Sources */,
 				BFD945E3244DC5E80012785A /* GitHubSearchViewController.swift in Sources */,
 				38D37C732A168B88005EA7C6 /* GitHubDetailWireFrame.swift in Sources */,
 				38D37C712A168AE8005EA7C6 /* GitHubDetailPresentation.swift in Sources */,
@@ -584,9 +598,11 @@
 				38D37C6D2A1688B6005EA7C6 /* GitHubSearchPresentation.swift in Sources */,
 				38F34E8D29FBA01900120671 /* GitHubApi.swift in Sources */,
 				38F34E8B29FA61BE00120671 /* UIViewController+Extension.swift in Sources */,
+				388949CB2A17E5F500307A11 /* RepositoryManager.swift in Sources */,
 				38F34E6629F91F3000120671 /* GitHubSearchInteractor.swift in Sources */,
 				38F34E7729F920E600120671 /* GitHubDetailRouter.swift in Sources */,
 				38D37C6B2A16886E005EA7C6 /* GitHubSearchWireFrame.swift in Sources */,
+				388949C92A17E57100307A11 /* Order.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* GitHubDetailViewController.swift in Sources */,
 				38F34E6829F91F5400120671 /* GitHubSearchPresenter.swift in Sources */,
 				386069A029FC0CC400BCF6AE /* UIImageView+Extension.swift in Sources */,

--- a/iOSEngineerCodeCheck/GitHubSearch/Entity/Order.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Entity/Order.swift
@@ -1,0 +1,16 @@
+//
+//  Order.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 日高隼人 on 2023/05/20.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Star数ボタンに関する -
+enum Order {
+    case desc
+    case asc
+    case `default`
+}

--- a/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryItem.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryItem.swift
@@ -8,30 +8,8 @@
 
 import UIKit
 
-// MARK: - Star数ボタンに関する -
-enum StarOrder {
-    case desc
-    case asc
-    case `default`
-
-    var text: String {
-        switch self {
-        case .desc: return "☆ Star数 ⍋"
-        case .asc: return "☆ Star数 ⍒"
-        case .`default`: return "☆ Star数 "
-        }
-    }
-
-    var color: UIColor {
-        switch self {
-        case .desc: return #colorLiteral(red: 0.1634489, green: 0.1312818527, blue: 0.2882181406, alpha: 1)
-        case .asc: return #colorLiteral(red: 0.1634489, green: 0.1312818527, blue: 0.2882181406, alpha: 1)
-        case .`default`: return .lightGray
-        }
-    }
-}
 ///  リポジトリを表示する順序に関する
-protocol OrderRepository {
+protocol RepositoryItem {
     var items: [Item?] { get set }
     var text: String { get }
     var color: UIColor { get }
@@ -40,7 +18,7 @@ protocol OrderRepository {
 }
 
 /// 順序がデフォルト時の際に使用する
-struct DefaultRepository: OrderRepository {
+struct DefaultRepository: RepositoryItem {
     var items: [Item?]
     var word: String
     var text: String
@@ -64,7 +42,7 @@ struct DefaultRepository: OrderRepository {
 }
 
 /// スター数が多い順の際に使用する
-struct DescRepository: OrderRepository {
+struct DescRepository: RepositoryItem {
     var items: [Item?]
     var word: String
     var text: String
@@ -88,13 +66,13 @@ struct DescRepository: OrderRepository {
 }
 
 /// スター数が少ない順の際に使用する
-struct AscRepository: OrderRepository {
+struct AscRepository: RepositoryItem {
     var items: [Item?]
     var word: String
     var text: String
     var color: UIColor
 
-    init(word: String) {
+    init(word: String = "") {
         self.items = []
         self.word = word
         self.text = "☆ Star数 ⍒"

--- a/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryItem.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryItem.swift
@@ -36,7 +36,7 @@ struct DefaultRepository: RepositoryItem {
         components.scheme = "https"
         components.host = "api.github.com"
         components.path = "/search/repositories"
-        components.queryItems = [.init(name: "q", value: word)]
+        components.queryItems = [.init(name: "q", value: word), .init(name: "per_page", value: "50")]
         return components.url
     }
 }
@@ -60,7 +60,7 @@ struct DescRepository: RepositoryItem {
         components.scheme = "https"
         components.host = "api.github.com"
         components.path = "/search/repositories"
-        components.queryItems = [.init(name: "q", value: word), .init(name: "order", value: "desc"), .init(name: "per_page", value: "60")]
+        components.queryItems = [.init(name: "q", value: word), .init(name: "order", value: "desc"), .init(name: "per_page", value: "50")]
         return components.url
     }
 }
@@ -84,7 +84,7 @@ struct AscRepository: RepositoryItem {
         components.scheme = "https"
         components.host = "api.github.com"
         components.path = "/search/repositories"
-        components.queryItems = [.init(name: "q", value: word), .init(name: "order", value: "asc"), .init(name: "per_page", value: "60")]
+        components.queryItems = [.init(name: "q", value: word), .init(name: "order", value: "asc"), .init(name: "per_page", value: "50")]
         return components.url
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryItem.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryItem.swift
@@ -36,7 +36,10 @@ struct DefaultRepository: RepositoryItem {
         components.scheme = "https"
         components.host = "api.github.com"
         components.path = "/search/repositories"
-        components.queryItems = [.init(name: "q", value: word), .init(name: "per_page", value: "50")]
+        components.queryItems = [
+                .init(name: "q", value: word),
+                .init(name: "per_page", value: "50")
+        ]
         return components.url
     }
 }
@@ -60,7 +63,12 @@ struct DescRepository: RepositoryItem {
         components.scheme = "https"
         components.host = "api.github.com"
         components.path = "/search/repositories"
-        components.queryItems = [.init(name: "q", value: word), .init(name: "order", value: "desc"), .init(name: "per_page", value: "50")]
+        components.queryItems = [
+                .init(name: "q", value: word),
+                .init(name: "sort", value: "stars"),
+                .init(name: "order", value: "desc"),
+                .init(name: "per_page", value: "50")
+        ]
         return components.url
     }
 }
@@ -84,7 +92,12 @@ struct AscRepository: RepositoryItem {
         components.scheme = "https"
         components.host = "api.github.com"
         components.path = "/search/repositories"
-        components.queryItems = [.init(name: "q", value: word), .init(name: "order", value: "asc"), .init(name: "per_page", value: "50")]
+        components.queryItems = [
+                .init(name: "q", value: word),
+                .init(name: "sort", value: "stars"),
+                .init(name: "order", value: "asc"),
+                .init(name: "per_page", value: "50")
+        ]
         return components.url
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryManager.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryManager.swift
@@ -1,0 +1,23 @@
+//
+//  Repositories.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 日高隼人 on 2023/05/20.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct RepositoryManager {
+    var currentRepository: RepositoryItem
+    var defaultRepository: DefaultRepository
+    var descRepository: DescRepository
+    var ascRepository: AscRepository
+
+    init(currentRepository: RepositoryItem! = DefaultRepository()) {
+        self.currentRepository = currentRepository
+        self.defaultRepository = DefaultRepository()
+        self.descRepository = DescRepository()
+        self.ascRepository = AscRepository()
+    }
+}

--- a/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryManager.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Entity/RepositoryManager.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 struct RepositoryManager {
-    var currentRepository: RepositoryItem
-    var defaultRepository: DefaultRepository
-    var descRepository: DescRepository
-    var ascRepository: AscRepository
+    var current: RepositoryItem
+    var `default`: DefaultRepository
+    var desc: DescRepository
+    var asc: AscRepository
 
     init(currentRepository: RepositoryItem! = DefaultRepository()) {
-        self.currentRepository = currentRepository
-        self.defaultRepository = DefaultRepository()
-        self.descRepository = DescRepository()
-        self.ascRepository = AscRepository()
+        self.current = currentRepository
+        self.`default` = DefaultRepository()
+        self.desc = DescRepository()
+        self.asc = AscRepository()
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchInteractor.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchInteractor.swift
@@ -15,9 +15,8 @@ final class GitHubSearchInteractor {
 
 extension GitHubSearchInteractor: GitHubSearchInputUsecase {
     /// データベースから GitHubデータを取得。
-
-    func fetch(orderRepository: RepositoryItem) {
-        apiManager.fetch(orderRepository: orderRepository) { [weak self] result in
+    func fetch(word: String) {
+        apiManager.fetch(word: word) { [weak self] result in
             self?.presenter?.didFetchResult(result: result)
         }
     }

--- a/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchInteractor.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchInteractor.swift
@@ -16,7 +16,7 @@ final class GitHubSearchInteractor {
 extension GitHubSearchInteractor: GitHubSearchInputUsecase {
     /// データベースから GitHubデータを取得。
 
-    func fetch(orderRepository: OrderRepository) {
+    func fetch(orderRepository: RepositoryItem) {
         apiManager.fetch(orderRepository: orderRepository) { [weak self] result in
             self?.presenter?.didFetchResult(result: result)
         }

--- a/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchUsecase.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchUsecase.swift
@@ -14,11 +14,11 @@ protocol GitHubSearchInputUsecase: AnyObject {
     /// gitHubApiにアクセスする
     var apiManager: ApiManager { get }
     /// API通信を行い、GitHubのデータをデータベースから取得
-    func fetch(orderRepository: RepositoryItem)
+    func fetch(word: String)
 }
 
 // Interactor アウトプット
 protocol GitHubSearchOutputUsecase: AnyObject {
     /// 取得したGitHubデータの結果をPresenterへ通知
-    func didFetchResult(result: Result<GitHubSearchEntity, ApiError>)
+    func didFetchResult(result: Result<RepositoryEntity, ApiError>)
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchUsecase.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Interactor/GitHubSearchUsecase.swift
@@ -14,7 +14,7 @@ protocol GitHubSearchInputUsecase: AnyObject {
     /// gitHubApiにアクセスする
     var apiManager: ApiManager { get }
     /// API通信を行い、GitHubのデータをデータベースから取得
-    func fetch(orderRepository: OrderRepository)
+    func fetch(orderRepository: RepositoryItem)
 }
 
 // Interactor アウトプット

--- a/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresentation.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresentation.swift
@@ -13,11 +13,11 @@ protocol GitHubSearchPresentation: AnyObject {
     var view: GitHubSearchView? { get }
     var interactor: GitHubSearchInputUsecase { get }
     var router: GitHubSearchWireFrame { get }
-    var orderRepository: OrderRepository! { get set }
+    var repository: RepositoryManager { get }
 
     func viewDidLoad()
     /// サーチボタンのタップ通知
-    func searchButtonDidPush(orderRepository: OrderRepository)
+    func searchButtonDidPush(orderRepository: RepositoryItem)
     /// 検索テキストの変更を通知
     func searchTextDidChange()
     /// セルタップを通知

--- a/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresentation.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresentation.swift
@@ -17,7 +17,7 @@ protocol GitHubSearchPresentation: AnyObject {
 
     func viewDidLoad()
     /// サーチボタンのタップ通知
-    func searchButtonDidPush(repositoryItem: RepositoryItem)
+    func searchButtonDidPush(word: String)
     /// 検索テキストの変更を通知
     func searchTextDidChange()
     /// セルタップを通知

--- a/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresentation.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresentation.swift
@@ -17,7 +17,7 @@ protocol GitHubSearchPresentation: AnyObject {
 
     func viewDidLoad()
     /// サーチボタンのタップ通知
-    func searchButtonDidPush(orderRepository: RepositoryItem)
+    func searchButtonDidPush(repositoryItem: RepositoryItem)
     /// 検索テキストの変更を通知
     func searchTextDidChange()
     /// セルタップを通知

--- a/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresenter.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresenter.swift
@@ -12,8 +12,8 @@ final class GitHubSearchPresenter {
     weak var view: GitHubSearchView?
     var interactor: GitHubSearchInputUsecase
     var router: GitHubSearchWireFrame
-
-    var orderRepository: OrderRepository!
+    var repository = RepositoryManager()
+    var order: Order = .default
 
     init(
         view: GitHubSearchView? = nil,
@@ -31,7 +31,7 @@ extension GitHubSearchPresenter: GitHubSearchPresentation {
     }
 
     /// 検索ボタンのタップを検知。 GitHubデータのリセット。ローディングの開始。GitHubデータの取得を通知。
-    func searchButtonDidPush(orderRepository: OrderRepository) {
+    func searchButtonDidPush(orderRepository: RepositoryItem) {
         view?.resetDisplay()
         view?.startLoading()
         interactor.fetch(orderRepository: orderRepository)
@@ -47,29 +47,16 @@ extension GitHubSearchPresenter: GitHubSearchPresentation {
     func didSelectRow(item: Item) {
         router.showGitHubDetailViewController(item: item)
     }
-
     /// スター数順の変更ボタンのタップを検知。(スター数で降順・昇順を切り替え)
     func starOderButtonDidPush() {
-//        switch starOrder {
-//        case .`default`:
-//            changeOrder(
-//                starOrder: .desc,
-//                // スター数が多い順にソート
-//                items: items.sorted { $0.stargazersCount > $01.stargazersCount }
-//            )
-//        case .desc:
-//            changeOrder(
-//                starOrder: .asc,
-//                // スター数が少ない順にソート
-//                items: items.sorted { $0.stargazersCount < $01.stargazersCount }
-//            )
-//        case .asc:
-//            changeOrder(
-//                starOrder: .default,
-//                // デフォルトの順番
-//                items: defaultItems
-//            )
-//        }
+        switch order {
+        case .`default`:
+            break
+        case .desc:
+            break
+        case .asc:
+            break
+        }
     }
 }
 
@@ -80,8 +67,16 @@ extension GitHubSearchPresenter: GitHubSearchOutputUsecase {
         view?.stopLoading()
         switch result {
         case .success(let gitHubData):
-            //  データの取得が成功した場合は、 GitHubリストのデフォルトに保管。
-            self.orderRepository?.items = gitHubData.items!
+            repository.current.items = gitHubData.items!
+
+            switch order {
+            case .`default`:
+                repository.`default`.items = gitHubData.items!
+            case .desc:
+                repository.desc.items = gitHubData.items!
+            case .asc:
+                repository.asc.items = gitHubData.items!
+            }
             view?.tableViewReload()
         case .failure(let error):
             if error == .notFound {
@@ -93,7 +88,4 @@ extension GitHubSearchPresenter: GitHubSearchOutputUsecase {
             }
         }
     }
-}
-// MARK: - このファイル内のみで使用する。 -
-private extension GitHubSearchPresenter {
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresenter.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/Presenter/GitHubSearchPresenter.swift
@@ -31,14 +31,16 @@ extension GitHubSearchPresenter: GitHubSearchPresentation {
     }
 
     /// 検索ボタンのタップを検知。 GitHubデータのリセット。ローディングの開始。GitHubデータの取得を通知。
-    func searchButtonDidPush(orderRepository: RepositoryItem) {
+    func searchButtonDidPush(repositoryItem: RepositoryItem) {
+        resetRepository()
         view?.resetDisplay()
         view?.startLoading()
-        interactor.fetch(orderRepository: orderRepository)
+        interactor.fetch(orderRepository: repositoryItem)
     }
 
     /// テキスト変更を検知。GitHubデータと画面の状態をリセット。タスクのキャンセル
     func searchTextDidChange() {
+        resetRepository()
         view?.resetDisplay()
         interactor.apiManager.task?.cancel()
     }
@@ -51,12 +53,18 @@ extension GitHubSearchPresenter: GitHubSearchPresentation {
     func starOderButtonDidPush() {
         switch order {
         case .`default`:
-            break
+            order = .desc
+            repository.current = repository.desc
         case .desc:
-            break
+            order = .asc
+            repository.current = repository.asc
         case .asc:
-            break
+            order = .`default`
+            repository.current = repository.`default`
         }
+
+        view?.didChangeStarOrder(repository: repository.current)
+        view?.tableViewReload()
     }
 }
 
@@ -87,5 +95,14 @@ extension GitHubSearchPresenter: GitHubSearchOutputUsecase {
                 view?.appearErrorAlert(message: error.errorDescription!)
             }
         }
+    }
+}
+
+private extension GitHubSearchPresenter {
+    func resetRepository() {
+        repository.current.items = []
+        repository.default.items = []
+        repository.desc.items = []
+        repository.asc.items = []
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchView.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchView.swift
@@ -18,5 +18,5 @@ protocol GitHubSearchView: AnyObject {
     func resetDisplay()
     func appearErrorAlert(message: String)
     func appearNotFound(text: String)
-    func didChangeStarOrder(repository: RepositoryManager)
+    func didChangeStarOrder(repository: RepositoryItem)
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchView.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchView.swift
@@ -18,5 +18,5 @@ protocol GitHubSearchView: AnyObject {
     func resetDisplay()
     func appearErrorAlert(message: String)
     func appearNotFound(text: String)
-    func didChangeStarOrder(starOrder: StarOrder)
+    func didChangeStarOrder(repository: RepositoryManager)
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
@@ -140,9 +140,7 @@ extension GitHubSearchViewController: UISearchBarDelegate {
         // テキストが空、もしくはローディング中はタップ無効。
         guard let text = searchBar.text, !text.isEmpty, !isLoading else { return }
         // 検索ボタンのタップを通知。 GitHubデータを取得の指示。
-        var repository = presenter.repository.current
-        repository.word = text
-        presenter.searchButtonDidPush(repositoryItem: repository)
+        presenter.searchButtonDidPush(word: text)
         searchBar.resignFirstResponder()
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
@@ -121,9 +121,9 @@ extension GitHubSearchViewController: GitHubSearchView {
     }
 
     /// ボタンの見た目を変更する
-    func didChangeStarOrder(repository: RepositoryManager) {
-        starOderButton.setTitle(repository.current.text, for: .normal)
-        starOderButton.backgroundColor = repository.current.color
+    func didChangeStarOrder(repository: RepositoryItem) {
+        starOderButton.setTitle(repository.text, for: .normal)
+        starOderButton.backgroundColor = repository.color
     }
 }
 
@@ -142,7 +142,7 @@ extension GitHubSearchViewController: UISearchBarDelegate {
         // 検索ボタンのタップを通知。 GitHubデータを取得の指示。
         var repository = presenter.repository.current
         repository.word = text
-        presenter.searchButtonDidPush(orderRepository: repository)
+        presenter.searchButtonDidPush(repositoryItem: repository)
         searchBar.resignFirstResponder()
     }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
@@ -67,7 +67,6 @@ extension GitHubSearchViewController: GitHubSearchView {
         notFoundLabel.text = nil
         frontView.isHidden = true
         setupNavigationBar(title: "ホーム")
-        presenter.orderRepository = DefaultRepository()
     }
 
     /// 画面の状態をリセットする
@@ -122,9 +121,9 @@ extension GitHubSearchViewController: GitHubSearchView {
     }
 
     /// ボタンの見た目を変更する
-    func didChangeStarOrder(starOrder: StarOrder) {
-        starOderButton.setTitle(starOrder.text, for: .normal)
-        starOderButton.backgroundColor = starOrder.color
+    func didChangeStarOrder(repository: RepositoryManager) {
+        starOderButton.setTitle(repository.current.text, for: .normal)
+        starOderButton.backgroundColor = repository.current.color
     }
 }
 
@@ -141,16 +140,16 @@ extension GitHubSearchViewController: UISearchBarDelegate {
         // テキストが空、もしくはローディング中はタップ無効。
         guard let text = searchBar.text, !text.isEmpty, !isLoading else { return }
         // 検索ボタンのタップを通知。 GitHubデータを取得の指示。
-        var repository = presenter.orderRepository
-        repository?.word = text
-        presenter.searchButtonDidPush(orderRepository: repository!)
+        var repository = presenter.repository.current
+        repository.word = text
+        presenter.searchButtonDidPush(orderRepository: repository)
         searchBar.resignFirstResponder()
     }
 }
 
 extension GitHubSearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return presenter.orderRepository?.items.count ?? 0
+        return presenter.repository.current.items.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -159,7 +158,7 @@ extension GitHubSearchViewController: UITableViewDataSource {
         // 写真表示をリセット
         cell.avatarImage.image = nil
 
-        guard let item = presenter.orderRepository?.items[indexPath.row] else { return UITableViewCell() }
+        guard let item = presenter.repository.current.items[indexPath.row] else { return UITableViewCell() }
 
         cell.configure(
             fullName: item.fullName,
@@ -176,7 +175,7 @@ extension GitHubSearchViewController: UITableViewDataSource {
 
 extension GitHubSearchViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let item = presenter.orderRepository?.items[indexPath.row] else { return }
+        guard let item = presenter.repository.current.items[indexPath.row] else { return }
         // セルタップを通知。GitHubデータを渡してます。
         presenter.didSelectRow(item: item)
     }

--- a/iOSEngineerCodeCheck/Utilities/Entity/RepositoryEntity.swift
+++ b/iOSEngineerCodeCheck/Utilities/Entity/RepositoryEntity.swift
@@ -1,0 +1,22 @@
+//
+//  RepositoryEntity.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 日高隼人 on 2023/05/20.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct RepositoryEntity {
+    let `default`: GitHubSearchEntity
+    let desc: GitHubSearchEntity
+    let asc: GitHubSearchEntity
+
+    init(`default`: GitHubSearchEntity, desc: GitHubSearchEntity, asc: GitHubSearchEntity) {
+        self.default = `default`
+        self.desc = desc
+        self.asc = asc
+    }
+}
+

--- a/iOSEngineerCodeCheck/Utilities/GitHubApi.swift
+++ b/iOSEngineerCodeCheck/Utilities/GitHubApi.swift
@@ -10,26 +10,33 @@ import Foundation
 
 // MARK: - GitHub API通信で使用する -
 final class ApiManager {
-    var decoder: JSONDecoder = JSONDecoder()
-    var result: (Result<GitHubSearchEntity, ApiError>)?
-    var task: Task<(), Never>?
+    private var decoder: JSONDecoder = JSONDecoder()
+    private (set) var task: Task<(), Never>?
 }
 
 // MARK: - 他ファイルから使用するる類 -
 extension ApiManager {
     /// GitHubデータベースから取得した結果を返す。
-    func fetch(orderRepository: RepositoryItem, completion: @escaping(Result<GitHubSearchEntity, ApiError>) -> Void) {
+    func fetch(word: String, completion: @escaping(Result<RepositoryEntity, ApiError>) -> Void) {
         task = Task {
             do {
-                let request = try self.urlRequest(url: orderRepository.url)
-                let gitHubData = try await convert(request: request)
-                result = .success(gitHubData)
-                completion(result!)
+                let request = try urlRequest(word: word)
+
+                async let defaultRepository = convert(request: request.default)
+                async let descRepository = convert(request: request.desc)
+                async let ascRepository = convert(request: request.asc)
+
+                let repository = RepositoryEntity(
+                    default: try await defaultRepository,
+                    desc: try await descRepository,
+                    asc: try await ascRepository)
+
+                completion(.success(repository))
             } catch let apiError {
                 // タスクをキャンセルされたらリターン
                 if Task.isCancelled { return }
-                result = .failure(apiError as? ApiError ?? .unknown)
-                completion(result!)
+
+                completion(.failure(apiError as? ApiError ?? .unknown))
             }
         }
     }
@@ -38,12 +45,20 @@ extension ApiManager {
 // MARK: - API通信を行なうための部品類 -
 private extension ApiManager {
     /// リクエスト生成。URLがない場合、NotFoundエラーを返す。
-    func urlRequest(url: URL?) throws -> URLRequest {
-        guard let url: URL = url else {
+    func urlRequest(word: String) throws -> (`default`: URLRequest, desc: URLRequest, asc: URLRequest) {
+        guard
+            let defaultURL: URL = DefaultRepository(word: word).url,
+            let descURL: URL = DescRepository(word: word).url,
+            let ascURL: URL = AscRepository(word: word).url
+            else {
             throw ApiError.notFound
         }
-        let request = URLRequest(url: url)
-        return request
+
+        let defaultRequest = URLRequest(url: defaultURL)
+        let descRequest = URLRequest(url: descURL)
+        let ascRequest = URLRequest(url: ascURL)
+
+        return (defaultRequest, descRequest, ascRequest)
     }
 
     /// API通信。デコード。GitHubデータへ変換。

--- a/iOSEngineerCodeCheck/Utilities/GitHubApi.swift
+++ b/iOSEngineerCodeCheck/Utilities/GitHubApi.swift
@@ -18,7 +18,7 @@ final class ApiManager {
 // MARK: - 他ファイルから使用するる類 -
 extension ApiManager {
     /// GitHubデータベースから取得した結果を返す。
-    func fetch(orderRepository: OrderRepository, completion: @escaping(Result<GitHubSearchEntity, ApiError>) -> Void) {
+    func fetch(orderRepository: RepositoryItem, completion: @escaping(Result<GitHubSearchEntity, ApiError>) -> Void) {
         task = Task {
             do {
                 let request = try self.urlRequest(url: orderRepository.url)


### PR DESCRIPTION
GitHub APIから正確なスター数の順序(降順・昇順)で取得するように変更した。
前回までは、デフォルトのリポジトリデータのみを取ってきて、その順番をソートしていただけなので、実際のGitHub API の順序とは異なるため変更しました。
