### PR TITLE
 画像の取得処理をTableViewCellから削除。

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		049329AF80B2D1AF611F8FBE /* Pods_iOSEngineerCodeCheckTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6800159216A43DB8C841CD73 /* Pods_iOSEngineerCodeCheckTests.framework */; };
 		08BF68F158EBC28B42E4CFAD /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 282A5810E3EA27C8C1BD0C41 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */; };
+		380A2F992A191DCF009941A6 /* AvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A2F982A191DCF009941A6 /* AvatarImageView.swift */; };
 		386069A029FC0CC400BCF6AE /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3860699F29FC0CC400BCF6AE /* UIImageView+Extension.swift */; };
 		386069A429FD164300BCF6AE /* SearchRepositoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386069A329FD164300BCF6AE /* SearchRepositoryItem.swift */; };
 		388949C92A17E57100307A11 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949C82A17E57100307A11 /* Order.swift */; };
@@ -66,6 +67,7 @@
 /* Begin PBXFileReference section */
 		282A5810E3EA27C8C1BD0C41 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A7C55CFD63E6B2D8C5483EB /* Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; path = "Target Support Files/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		380A2F982A191DCF009941A6 /* AvatarImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarImageView.swift; sourceTree = "<group>"; };
 		3860699F29FC0CC400BCF6AE /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
 		386069A329FD164300BCF6AE /* SearchRepositoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryItem.swift; sourceTree = "<group>"; };
 		388949C82A17E57100307A11 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 			children = (
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				38D37C642A168715005EA7C6 /* GitHubSearchView.swift */,
+				380A2F982A191DCF009941A6 /* AvatarImageView.swift */,
 				BFD945E2244DC5E80012785A /* GitHubSearchViewController.swift */,
 				38F34E7F29F9574F00120671 /* GitHubSearchTableViewCell.swift */,
 			);
@@ -605,6 +608,7 @@
 				38F34E6629F91F3000120671 /* GitHubSearchInteractor.swift in Sources */,
 				38F34E7729F920E600120671 /* GitHubDetailRouter.swift in Sources */,
 				38D37C6B2A16886E005EA7C6 /* GitHubSearchWireFrame.swift in Sources */,
+				380A2F992A191DCF009941A6 /* AvatarImageView.swift in Sources */,
 				388949C92A17E57100307A11 /* Order.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* GitHubDetailViewController.swift in Sources */,
 				38F34E6829F91F5400120671 /* GitHubSearchPresenter.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		049329AF80B2D1AF611F8FBE /* Pods_iOSEngineerCodeCheckTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6800159216A43DB8C841CD73 /* Pods_iOSEngineerCodeCheckTests.framework */; };
 		08BF68F158EBC28B42E4CFAD /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 282A5810E3EA27C8C1BD0C41 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */; };
 		380A2F992A191DCF009941A6 /* AvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A2F982A191DCF009941A6 /* AvatarImageView.swift */; };
+		380A2F9B2A193BA5009941A6 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380A2F9A2A193BA5009941A6 /* ImageLoader.swift */; };
 		386069A029FC0CC400BCF6AE /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3860699F29FC0CC400BCF6AE /* UIImageView+Extension.swift */; };
 		386069A429FD164300BCF6AE /* SearchRepositoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386069A329FD164300BCF6AE /* SearchRepositoryItem.swift */; };
 		388949C92A17E57100307A11 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388949C82A17E57100307A11 /* Order.swift */; };
@@ -68,6 +69,7 @@
 		282A5810E3EA27C8C1BD0C41 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A7C55CFD63E6B2D8C5483EB /* Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; path = "Target Support Files/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		380A2F982A191DCF009941A6 /* AvatarImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarImageView.swift; sourceTree = "<group>"; };
+		380A2F9A2A193BA5009941A6 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		3860699F29FC0CC400BCF6AE /* UIImageView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extension.swift"; sourceTree = "<group>"; };
 		386069A329FD164300BCF6AE /* SearchRepositoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryItem.swift; sourceTree = "<group>"; };
 		388949C82A17E57100307A11 /* Order.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				388949CC2A18C63000307A11 /* GitHubRepositories.swift */,
 				38F34E6929F91F7100120671 /* RepositoryItem.swift */,
 				38F34E8C29FBA01900120671 /* GitHubApi.swift */,
+				380A2F9A2A193BA5009941A6 /* ImageLoader.swift */,
 				38F34E7D29F952B800120671 /* ApiError.swift */,
 			);
 			path = ApiResouse;
@@ -598,6 +601,7 @@
 				38F34E6A29F91F7100120671 /* RepositoryItem.swift in Sources */,
 				386069A429FD164300BCF6AE /* SearchRepositoryItem.swift in Sources */,
 				BFD945E3244DC5E80012785A /* GitHubSearchViewController.swift in Sources */,
+				380A2F9B2A193BA5009941A6 /* ImageLoader.swift in Sources */,
 				38D37C732A168B88005EA7C6 /* GitHubDetailWireFrame.swift in Sources */,
 				38D37C712A168AE8005EA7C6 /* GitHubDetailPresentation.swift in Sources */,
 				38F34E7429F920A300120671 /* GitHubDetailPresenter.swift in Sources */,

--- a/iOSEngineerCodeCheck/GitHubSearch/View/AvatarImageView.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/AvatarImageView.swift
@@ -8,14 +8,26 @@
 
 import UIKit
 
-class AvatarImageView: UIImageView {
+final class AvatarImageView: UIImageView {
+    private let imageLoader = ImageLoader()
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        accessibilityIgnoresInvertColors = true
+        layer.cornerRadius = 6
     }
-    */
 
+    func load(url: URL?) async {
+        do {
+            imageLoader.cancel()
+            let image = try await imageLoader.load(url: url)
+            DispatchQueue.main.async { [weak self] in
+                self?.image = image.resize()
+            }
+        } catch {
+            DispatchQueue.main.async { [weak self] in
+                self?.image = UIImage(named: "Untitled")
+            }
+        }
+    }
 }

--- a/iOSEngineerCodeCheck/GitHubSearch/View/AvatarImageView.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/AvatarImageView.swift
@@ -1,1 +1,21 @@
+//
+//  AvatarImageView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 日高隼人 on 2023/05/21.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
 
+import UIKit
+
+class AvatarImageView: UIImageView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/iOSEngineerCodeCheck/GitHubSearch/View/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/Base.lproj/Main.storyboard
@@ -34,7 +34,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SUq-hS-P6u">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SUq-hS-P6u" customClass="AvatarImageView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
                                                     <rect key="frame" x="26" y="10" width="65" height="65"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="65" id="22F-Xn-Su8"/>
@@ -84,7 +84,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="avatarImageView" destination="SUq-hS-P6u" id="hKB-f5-z6l"/>
+                                            <outlet property="avatarImageView" destination="SUq-hS-P6u" id="W9F-cA-mhY"/>
                                             <outlet property="fullNameLabel" destination="RlK-vK-39u" id="MDX-5l-Dr9"/>
                                             <outlet property="languageLabel" destination="MS1-kr-SfU" id="PIn-ac-D4r"/>
                                             <outlet property="starsLabel" destination="Vgh-Ro-zjZ" id="KhI-l7-etp"/>

--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
@@ -166,7 +166,7 @@ extension GitHubSearchViewController: UITableViewDataSource {
 
         let url = item.owner.avatarUrl
 
-        cell.avatarImage(url: url)
+        cell.setAvatarImage(url: url)
         return cell
     }
 }

--- a/iOSEngineerCodeCheck/Utilities/ApiResouse/GitHubApi.swift
+++ b/iOSEngineerCodeCheck/Utilities/ApiResouse/GitHubApi.swift
@@ -14,7 +14,7 @@ final class ApiManager {
     private (set) var task: Task<(), Never>?
 }
 
-// MARK: - 他ファイルから使用するる類 -
+// MARK: - 他ファイルから使用する類 -
 extension ApiManager {
     /// GitHub APIから取得した結果を返す。
     func fetch(word: String, completion: @escaping(Result<GitHubRepositories, ApiError>) -> Void) {
@@ -33,9 +33,6 @@ extension ApiManager {
 
                 completion(.success(repository))
             } catch let apiError {
-                // タスクをキャンセルされたらリターン
-                if Task.isCancelled { return }
-
                 completion(.failure(apiError as? ApiError ?? .unknown))
             }
         }
@@ -45,7 +42,7 @@ extension ApiManager {
 // MARK: - API通信を行なうための部品類 -
 private extension ApiManager {
     /// リクエスト生成。URLがない場合、NotFoundエラーを返す。
-    func urlRequest(word: String) throws -> (`default`: URLRequest, desc: URLRequest, asc: URLRequest) {  // swiftlint:disable:this all
+    func urlRequest(word: String) throws -> (`default`: URLRequest, desc: URLRequest, asc: URLRequest) { // swiftlint:disable:this all
 
         guard
             let defaultURL: URL = DefaultRepository(word: word).url,

--- a/iOSEngineerCodeCheck/Utilities/ApiResouse/ImageLoader.swift
+++ b/iOSEngineerCodeCheck/Utilities/ApiResouse/ImageLoader.swift
@@ -1,0 +1,9 @@
+//
+//  ImageLoader.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 日高隼人 on 2023/05/21.
+//  Copyright © 2023 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
画像を取得するのは TableViewCell の責務ではないため。

ImageLoaderをファイル作成 (API通信処理を行なう)
画像の取得はカスタムUIImageViewクラスを作成しそちらで行なうこととした。
