### PR TITLE
冗長な処理の削除

### DIFF
--- a/iOSEngineerCodeCheck/Utilities/Api/GitHubRepositoryApi/GitHubRepositoryListCachedRepository.swift
+++ b/iOSEngineerCodeCheck/Utilities/Api/GitHubRepositoryApi/GitHubRepositoryListCachedRepository.swift
@@ -27,11 +27,7 @@ extension GitHubRepositoryListCachedRepository {
             setRepositoryItem(order: order, items: item.items)
             return .success(item.items)
         } catch {
-            if let apiError = error as? ApiError {
-                return .failure(apiError)
-            } else {
-                return .failure(error)
-            }
+            return .failure(error)
         }
     }
 


### PR DESCRIPTION
## 概要

冗長処理を修正しました。

## 実装について

### 修正前

具体型 `ApiError` にキャストしていますが当該処理は不要です。
結局、同一のオブジェクトが設定されています（キャスト処理はオブジェクトの変換処理ではないことに注意してください）

```swift
if let apiError = error as? ApiError {
   return .failure(apiError)
} else {
   return .failure(error)
}
```

### 修正後

冗長処理を削除しました。

```swift
return .failure(error)
```
