### PR TITLE
UITableViewDataSource 内でのセルの取得方法を変更

### DIFF
--- a/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitHubSearch/View/GitHubSearchViewController.swift
@@ -175,7 +175,7 @@ extension GitHubSearchViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: GitHubSearchTableViewCell.identifier) as? GitHubSearchTableViewCell else { return UITableViewCell() } // swiftlint:disable:this all
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: GitHubSearchTableViewCell.identifier, for: indexPath) as? GitHubSearchTableViewCell else { return UITableViewCell() } // swiftlint:disable:this all
         cell.selectionStyle = .none
 
         let item = presenter.item(at: indexPath.row)


### PR DESCRIPTION
## 概要

`tableView(_:cellForRowAt)` メソッドにおける、Cell の取得処理を変更しました。

## 実装について

`IndexPath` を指定するオーバーロードを呼び出すように変更しました。

```diff
- dequeueReusableCell(withIdentifier: GitHubSearchTableViewCell.identifier) ...
+ dequeueReusableCell(withIdentifier: GitHubSearchTableViewCell.identifier, for: indexPath) ...
```

UITableViewDataSource の `tableView(_:cellForRowAt:)` メソッドにおいては、当該メソッドを呼び出すことで非 Optional な Cell を返すことができます。

---

`IndexPath` を指定しないオーバーロードは当該メソッド以外での利用に留めたほうが良いと思います。

> ### [Discussion](https://developer.apple.com/documentation/uikit/uitableview/1614878-dequeuereusablecell#discussion)
> Call this method only from the `tableView(_:cellForRowAt:)` 
> method of your table view data source object. This method returns an existing cell of the specified type, if one is available, or it creates and returns a new cell using the class or storyboard you provided earlier. Don’t call this method outside of your data source’s tableView(_:cellForRowAt:) method. If you need to create cells at other times, call `dequeueReusableCell(withIdentifier:)` instead.